### PR TITLE
Fix MSCCL++ reduce primitive

### DIFF
--- a/msccl/language/mscclpp/ir.py
+++ b/msccl/language/mscclpp/ir.py
@@ -252,6 +252,7 @@ def dump_to_json(program: Program):
                 elif op.inst == Instruction.reduce or op.inst == Instruction.reduce_packet:
                     srcs = list(map(lambda x: {"buff": x.buffer.value, "off": x.index}, op.srcs))
                     dst = op.dst
+                    src = op.dst
                 elif op.inst == Instruction.nop:
                     instr = {
                         "name": op.inst.value,


### PR DESCRIPTION
This commit fixes the issue that MSCCL++ reduce primitive lacks src field.