### PR TITLE
Fix condition that checks if put operation can be fused

### DIFF
--- a/msccl/language/mscclpp/instruction_optimizer.py
+++ b/msccl/language/mscclpp/instruction_optimizer.py
@@ -122,8 +122,8 @@ class InstructionOptimizer:
         :return: True if operations are merged, False otherwise.
         """
         if (
-            next_op.inst == Instruction.put
-            or next_op.inst == Instruction.put_packet
+            (next_op.inst == Instruction.put
+            or next_op.inst == Instruction.put_packet)
             and same_tb(op, next_op)
             and same_count(op, next_op)
             and buf_dst_src_match(op, next_op)


### PR DESCRIPTION
The logical `and` has a higher precedence than the logical `or` in python. So if `next_op.inst == Instruction.put` then none of the other checks have to hold, for instance `same_tb()` can be false.